### PR TITLE
Support setting read and write deadlines on multiplexed connections

### DIFF
--- a/deadline.go
+++ b/deadline.go
@@ -1,0 +1,41 @@
+package cmux
+
+import (
+	"sync"
+	"time"
+)
+
+var (
+	maxDeadline = time.Unix(1<<63-62135596801, 999999999)
+)
+
+// deadline is a wrapper around connection deadlines that updates the deadline
+// if the logical connection was the last to set the deadline or if the new
+// deadline is less than the current deadline. This allows us to manage
+// deadlines on underlying connections even multiplexing virtual connections
+// over them.
+type deadline struct {
+	current time.Time
+	owner   *cmconn
+	doSet   func(time.Time) error
+	mx      sync.Mutex
+}
+
+func newDeadline(doSet func(time.Time) error) *deadline {
+	return &deadline{
+		current: maxDeadline,
+		owner:   nil,
+		doSet:   doSet,
+	}
+}
+
+func (d *deadline) set(by *cmconn, t time.Time) (err error) {
+	d.mx.Lock()
+	if by == d.owner || t.Before(d.current) {
+		err = d.doSet(t)
+		d.current = t
+		d.owner = by
+	}
+	d.mx.Unlock()
+	return
+}

--- a/dialer.go
+++ b/dialer.go
@@ -95,11 +95,7 @@ func (d *dialer) Dial(network, addr string) (net.Conn, error) {
 		conns[idx] = cs
 	}
 
-	return &cmconn{
-		wrapped: cs.conn,
-		stream:  stream,
-		onClose: cs.closeIfNecessary,
-	}, nil
+	return newConn(cs.conn, newDeadline(cs.conn.SetReadDeadline), newDeadline(cs.conn.SetWriteDeadline), stream, cs.closeIfNecessary), nil
 }
 
 func (d *dialer) connect(network, addr string, idx int) (*connAndSession, error) {


### PR DESCRIPTION
@joesis This may help with getlantern/lantern-internal#322.

Related to getlantern/idletiming#9