### PR TITLE
Bubble up invalid protocol errors on calls to Accept

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,5 @@ require (
 	github.com/getlantern/netx v0.0.0-20190110220209-9912de6f94fd
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
-	github.com/xtaci/smux v1.3.4
+	github.com/xtaci/smux v1.4.4
 )

--- a/go.sum
+++ b/go.sum
@@ -41,5 +41,5 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/xtaci/smux v1.3.4 h1:7BJNo6A3d8CJXV1cCwwN9lZaGigNB2BbSDKIbtf7bHE=
-github.com/xtaci/smux v1.3.4/go.mod h1:f+nYm6SpuHMy/SH0zpbvAFHT1QoMcgLOsWcFip5KfPw=
+github.com/xtaci/smux v1.4.4 h1:FukIfahko+KHhS9Gxppkp6756opZymvPOLNmpny1is4=
+github.com/xtaci/smux v1.4.4/go.mod h1:LuA3S0xssf4fmGRJ7ow3EehgmDUzib4EcobaFNKvlMA=

--- a/listener.go
+++ b/listener.go
@@ -1,14 +1,23 @@
 package cmux
 
 import (
+	"bytes"
 	"errors"
+	"io"
 	"net"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	pkgerrors "github.com/pkg/errors"
+
 	"github.com/xtaci/smux"
 )
+
+// When a caller invokes Accept and we receive an invalid protocol from a peer, we return an error
+// and the connection to the caller. To avoid leaks, we close the connection after a period if the
+// caller has not already done so.
+const invalidProtocolCloseDelay = time.Minute
 
 var (
 	ErrClosed = errors.New("listener closed")
@@ -34,7 +43,9 @@ type listener struct {
 }
 
 // Listen creates a net.Listener that multiplexes connections over a connection
-// obtained from the underlying opts.Listener.
+// obtained from the underlying opts.Listener. The Accept method will return
+// ErrorInvalidProtocol if a peer attempts to connect but does not use the
+// proper protocol.
 func Listen(opts *ListenOpts) net.Listener {
 	if opts.BufferSize <= 0 {
 		opts.BufferSize = defaultBufferSize
@@ -70,7 +81,8 @@ func (l *listener) handleConn(conn net.Conn) {
 	if l.KeepAliveInterval > 0 {
 		smuxConfig.KeepAliveInterval = l.KeepAliveInterval
 	}
-	session, err := smux.Server(conn, smuxConfig)
+	teeConn := newTeeConn(conn)
+	session, err := smux.Server(teeConn, smuxConfig)
 	if err != nil {
 		l.nextErr <- err
 		return
@@ -81,21 +93,37 @@ func (l *listener) handleConn(conn net.Conn) {
 	l.sessions[sessionID] = session
 	l.mx.Unlock()
 
+	// Note: we do not defer conn.Close because we may want to pass on an unclosed connection when
+	// receiving an invalid protocol.
 	defer func() {
 		session.Close()
-		conn.Close()
 		l.mx.Lock()
 		delete(l.sessions, sessionID)
 		l.mx.Unlock()
 		atomic.AddInt64(&l.numConnections, -1)
 	}()
 
+	firstAccept := true
 	for {
 		stream, err := session.AcceptStream()
-		if err != nil {
-			log.Debugf("Error creating multiplexed session, probably just means that the underlying connection was closed: %v", err)
+		if err != nil && firstAccept {
+			// An error accepting the first stream may indicate problems with the connection or a
+			// peer using an invalid protocol. These should be bubbled up to the caller.
+			if pkgerrors.Cause(err) == smux.ErrInvalidProtocol {
+				teeConn.cancelClose()
+				eip := ErrorInvalidProtocol{Cause: err, Conn: conn, ConnReader: teeConn.teeReader}
+				eip.startCloseTimer(invalidProtocolCloseDelay)
+				l.nextErr <- &eip
+			}
 			return
 		}
+		if err != nil {
+			log.Debugf("Error creating multiplexed session, probably just means that the underlying connection was closed: %v", err)
+			conn.Close()
+			return
+		}
+		firstAccept = false
+		teeConn.stopTee()
 		atomic.AddInt64(&l.numVirtualConnections, 1)
 		l.nextConn <- &cmconn{
 			Conn:    stream,
@@ -159,4 +187,82 @@ func (l *listener) logStats() {
 			return
 		}
 	}
+}
+
+// teeConn allows users to read from a connection, but retains the data read in teeBuf.
+type teeConn struct {
+	conn      net.Conn
+	teeReader io.Reader
+	read      atomic.Value // type: func([]byte) (int, error)
+	close     func() error
+}
+
+func newTeeConn(conn net.Conn) *teeConn {
+	var (
+		buf        = new(bytes.Buffer)
+		connReader = io.TeeReader(conn, buf)
+		teeReader  = io.MultiReader(buf, conn)
+		read       = atomic.Value{}
+	)
+	read.Store(connReader.Read)
+	return &teeConn{conn, teeReader, read, conn.Close}
+}
+
+func (tc *teeConn) Read(b []byte) (n int, err error) {
+	return tc.read.Load().(func([]byte) (int, error))(b)
+}
+
+// Stops the tee process. Read can still be used to read from the connection. The teeReader will be
+// set to nil.
+func (tc *teeConn) stopTee() {
+	tc.read.Store(tc.conn.Read)
+	tc.teeReader = nil
+}
+
+func (tc *teeConn) Write(b []byte) (n int, err error) { return tc.conn.Write(b) }
+func (tc *teeConn) Close() error                      { return tc.close() }
+func (tc *teeConn) cancelClose()                      { tc.close = func() error { return nil } }
+
+// ErrorInvalidProtocol is generated when a peer attempts to connect, but does not use the proper
+// protocol.
+type ErrorInvalidProtocol struct {
+	Cause error
+	Conn  net.Conn
+
+	// Some data will have been read off the connection already, but ConnReader will have all data
+	// transmitted by the peer.
+	ConnReader io.Reader
+
+	closeTimer         *time.Timer
+	abandonTimer       chan struct{}
+	stopCloseTimerOnce sync.Once
+}
+
+func (eip *ErrorInvalidProtocol) Error() string {
+	return eip.Cause.Error()
+}
+
+func (eip *ErrorInvalidProtocol) startCloseTimer(d time.Duration) {
+	eip.closeTimer = time.NewTimer(d)
+	eip.abandonTimer = make(chan struct{})
+	go func() {
+		select {
+		case <-eip.closeTimer.C:
+			eip.Conn.Close()
+		case <-eip.abandonTimer:
+		}
+	}()
+}
+
+// StopCloseTimer stops the timer controlling when the connection is closed. To avoid leaks, the
+// connection is closed some time after this error is created. However, you can control closing the
+// connection yourself by calling this function. The return value will be true if the call stops the
+// timer and false if the timer has already expired or been stopped.
+func (eip *ErrorInvalidProtocol) StopCloseTimer() bool {
+	stopped := false
+	eip.stopCloseTimerOnce.Do(func() {
+		close(eip.abandonTimer)
+		stopped = eip.closeTimer.Stop()
+	})
+	return stopped
 }

--- a/listener_test.go
+++ b/listener_test.go
@@ -1,0 +1,42 @@
+package cmux
+
+import (
+	"io"
+	"math/rand"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidProtocol(t *testing.T) {
+	t.Parallel()
+
+	// Make sure the peer message is larger than what smux will attempt to read.
+	peerMsg := make([]byte, 256)
+	_, err := rand.Read(peerMsg)
+	require.NoError(t, err)
+
+	_l, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	l := Listen(&ListenOpts{Listener: _l})
+	defer l.Close()
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	require.NoError(t, err)
+
+	_, err = conn.Write(peerMsg)
+	require.NoError(t, err)
+
+	_, err = l.Accept()
+	require.Error(t, err)
+	eip, ok := err.(*ErrorInvalidProtocol)
+	require.True(t, ok)
+	require.True(t, eip.StopCloseTimer())
+
+	b := make([]byte, len(peerMsg))
+	n, err := io.ReadFull(eip.ConnReader, b)
+	require.NoError(t, err)
+	require.Equal(t, peerMsg, b[:n])
+}


### PR DESCRIPTION
This is to support Apache mimicry when multiplexing, but really we need this to support any kind of request handling when multiplexing and receiving an invalid protocol.