### PR TITLE
Update smux to 1.5.10

### DIFF
--- a/cmux.go
+++ b/cmux.go
@@ -4,12 +4,11 @@ package cmux
 
 import (
 	"net"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/getlantern/golog"
-	"github.com/pkg/errors"
+	"github.com/xtaci/smux"
 )
 
 var (
@@ -60,12 +59,7 @@ func (c *cmconn) SetWriteDeadline(t time.Time) error {
 }
 
 func translateSmuxErr(err error) error {
-	err = errors.Cause(err)
-	if err == nil {
-		return err
-	} else if _, ok := err.(net.Error); ok {
-		return err
-	} else if strings.Contains(err.Error(), "timeout") { // certain newer versions
+	if err == smux.ErrTimeout {
 		return errTimeout
 	} else {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,5 @@ require (
 	github.com/getlantern/netx v0.0.0-20190110220209-9912de6f94fd
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
-	github.com/xtaci/smux v1.3.4
+	github.com/xtaci/smux v1.5.10
 )

--- a/go.sum
+++ b/go.sum
@@ -41,5 +41,5 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/xtaci/smux v1.3.4 h1:7BJNo6A3d8CJXV1cCwwN9lZaGigNB2BbSDKIbtf7bHE=
-github.com/xtaci/smux v1.3.4/go.mod h1:f+nYm6SpuHMy/SH0zpbvAFHT1QoMcgLOsWcFip5KfPw=
+github.com/xtaci/smux v1.5.10 h1:DM8CT6mO3b7u02NU6848Mb+nHJTK0rNE/qyzrEhNzn8=
+github.com/xtaci/smux v1.5.10/go.mod h1:OMlQbT5vcgl2gb49mFkYo6SMf+zP3rcjcwQz7ZU7IGY=


### PR DESCRIPTION
Partly because it fixed https://github.com/xtaci/smux/issues/61
It also introduces protocol version 2 with per stream flow control, which can potentially improve performance when deploying to both client and server.

With this we no longer need https://github.com/getlantern/smux/pull/1