### PR TITLE
Lock the sessions map when closing listener.

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -118,6 +118,8 @@ func (l *listener) Accept() (net.Conn, error) {
 func (l *listener) Close() (err error) {
 	l.closeOnce.Do(func() {
 		close(l.chClosed)
+		l.mx.Lock()
+		defer l.mx.Unlock()
 		for _, session := range l.sessions {
 			closeErr := session.Close()
 			if closeErr != nil {


### PR DESCRIPTION
Without the locking, in case when `l.handleConn` is running simultaneously with `l.Close`, "fatal error: concurrent map iteration and map write" can happen.