### PR TITLE
Lock the sessions map when closing listener.

### DIFF
--- a/v2/listener.go
+++ b/v2/listener.go
@@ -111,6 +111,8 @@ func (l *listener) Accept() (net.Conn, error) {
 func (l *listener) Close() (err error) {
 	l.closeOnce.Do(func() {
 		close(l.chClosed)
+		l.mx.Lock()
+		defer l.mx.Unlock()
 		for _, session := range l.sessions {
 			closeErr := session.Close()
 			if closeErr != nil {


### PR DESCRIPTION
applies https://github.com/getlantern/cmux/pull/18 to v2