### PR TITLE
Implement netx.WrappedConn interface

### DIFF
--- a/cmux.go
+++ b/cmux.go
@@ -7,8 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/getlantern/golog"
 	"github.com/xtaci/smux"
+
+	"github.com/getlantern/golog"
 )
 
 var (
@@ -19,9 +20,14 @@ var (
 
 type cmconn struct {
 	net.Conn
-	onClose func()
-	closed  bool
-	mx      sync.Mutex
+	wrappedConn net.Conn
+	onClose     func()
+	closed      bool
+	mx          sync.Mutex
+}
+
+func (c *cmconn) Wrapped() net.Conn {
+	return c.wrappedConn
 }
 
 func (c *cmconn) Close() error {

--- a/cmux_test.go
+++ b/cmux_test.go
@@ -10,11 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xtaci/smux"
+
 	"github.com/getlantern/fdcount"
 	"github.com/getlantern/keyman"
 	"github.com/getlantern/netx"
-	"github.com/stretchr/testify/assert"
-	"github.com/xtaci/smux"
 )
 
 func TestRoundTrip(t *testing.T) {
@@ -51,6 +53,7 @@ func TestRoundTrip(t *testing.T) {
 				log.Error(acceptErr)
 				return
 			}
+			require.IsType(t, &tls.Conn{}, conn.(*cmconn).Wrapped())
 			// Start echoing
 			go func() {
 				io.Copy(conn, conn)
@@ -78,6 +81,7 @@ func TestRoundTrip(t *testing.T) {
 		return
 	}
 	defer c1.Close()
+	require.IsType(t, &tls.Conn{}, c1.(*cmconn).Wrapped())
 	assert.NoError(t, fdc.AssertDelta(3), "Dialing connection 1 should have added one underlying connection (one file descriptor for each end of connection)")
 	assert.EqualValues(t, 1, atomic.LoadInt64(&l.numConnections))
 	assert.EqualValues(t, 1, atomic.LoadInt64(&l.numVirtualConnections))

--- a/dialer.go
+++ b/dialer.go
@@ -102,8 +102,9 @@ func (d *dialer) Dial(ctx context.Context, network, addr string) (net.Conn, erro
 	}
 
 	return &cmconn{
-		Conn:    stream,
-		onClose: cs.closeIfNecessary,
+		Conn:        stream,
+		wrappedConn: cs.conn,
+		onClose:     cs.closeIfNecessary,
 	}, nil
 }
 

--- a/listener.go
+++ b/listener.go
@@ -98,8 +98,9 @@ func (l *listener) handleConn(conn net.Conn) {
 		}
 		atomic.AddInt64(&l.numVirtualConnections, 1)
 		l.nextConn <- &cmconn{
-			Conn:    stream,
-			onClose: l.cmconnClosed,
+			Conn:        stream,
+			wrappedConn: conn,
+			onClose:     l.cmconnClosed,
 		}
 	}
 }

--- a/v2/cmux.go
+++ b/v2/cmux.go
@@ -20,10 +20,15 @@ type ErrorMapperFn func(error) error
 
 type cmconn struct {
 	net.Conn
+	wrappedConn    net.Conn
 	onClose        func()
 	closed         bool
 	mx             sync.Mutex
 	translateError ErrorMapperFn
+}
+
+func (c *cmconn) Wrapped() net.Conn {
+	return c.wrappedConn
 }
 
 func (c *cmconn) Close() error {

--- a/v2/dialer.go
+++ b/v2/dialer.go
@@ -98,6 +98,7 @@ func (d *dialer) Dial(ctx context.Context, network, addr string) (net.Conn, erro
 
 	return &cmconn{
 		Conn:           stream,
+		wrappedConn:    cs.conn,
 		onClose:        cs.closeIfNecessary,
 		translateError: d.Protocol.TranslateError,
 	}, nil

--- a/v2/listener.go
+++ b/v2/listener.go
@@ -91,6 +91,7 @@ func (l *listener) handleConn(conn net.Conn) {
 		atomic.AddInt64(&l.numVirtualConnections, 1)
 		l.nextConn <- &cmconn{
 			Conn:           stream,
+			wrappedConn:    conn,
 			onClose:        l.cmconnClosed,
 			translateError: l.Protocol.TranslateError,
 		}

--- a/v2/testhelpers.go
+++ b/v2/testhelpers.go
@@ -10,10 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/getlantern/fdcount"
 	"github.com/getlantern/keyman"
 	"github.com/getlantern/netx"
-	"github.com/stretchr/testify/assert"
 )
 
 func RunRoundTripTest(proto Protocol, t *testing.T) {
@@ -50,6 +52,7 @@ func RunRoundTripTest(proto Protocol, t *testing.T) {
 				log.Error(acceptErr)
 				return
 			}
+			require.IsType(t, &tls.Conn{}, conn.(*cmconn).Wrapped())
 			// Start echoing
 			go func() {
 				io.Copy(conn, conn)
@@ -77,6 +80,7 @@ func RunRoundTripTest(proto Protocol, t *testing.T) {
 		return
 	}
 	defer c1.Close()
+	require.IsType(t, &tls.Conn{}, c1.(*cmconn).Wrapped())
 	_, err = c1.Write([]byte("c1"))
 	if !assert.NoError(t, err) {
 		return


### PR DESCRIPTION
This is needed so that multiplexed protocols in http-proxy-lantern can peer past the cmux layer to get to the underlying connections.